### PR TITLE
Simplify readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,18 +184,11 @@ class HomeWidget extends StatelessWidget {
           ],
         ),
       ),
-      floatingActionButton: MomentumBuilder(
-        controllers: [CounterController],
-        // we don't need to rebuild the increment button.
-        dontRebuildIf: (_, __) => true,
-        builder: (context, snapshot) {
-          var controller = snapshot<CounterModel>().controller;
-          return FloatingActionButton(
-            onPressed: controller.increment,
-            tooltip: 'Increment',
-            child: Icon(Icons.add),
-          );
-        },
+      // we don't need to rebuild the increment button, we can skip the MomentumBuilder
+      floatingActionButton: FloatingActionButton(
+        onPressed: Momentum.controller<CounterController>(context).increment,
+        tooltip: 'Increment',
+        child: Icon(Icons.add),
       ),
     );
   }


### PR DESCRIPTION
If I understand the dependency injection correctly, the example of the readme ca be simplified a bit: around the `FloatingActionButton`:
- skip using a `MomentumBuilder`
- getting the controller directly via `Momentum.controller<CounterController>(context)`

Does this make sense? Or did I miss something?